### PR TITLE
Moves left head

### DIFF
--- a/proto/net.proto
+++ b/proto/net.proto
@@ -84,6 +84,13 @@ message Weights {
   optional Layer ip1_val_b = 8;
   optional Layer ip2_val_w = 9;
   optional Layer ip2_val_b = 10;
+
+  // Moves left head
+  optional ConvBlock moves_left = 12;
+  optional Layer ip1_mov_w = 13;
+  optional Layer ip1_mov_b = 14;
+  optional Layer ip2_mov_w = 15;
+  optional Layer ip2_mov_b = 16;
 }
 
 message TrainingParams {
@@ -139,6 +146,14 @@ message NetworkFormat {
     VALUE_WDL = 2;
   }
   optional ValueFormat value = 5;
+
+  // Moves left head architecture
+  enum MovesLeftFormat {
+    MOVES_LEFT_UNKNOWN = 0;
+    MOVES_LEFT_NONE = 1;
+    MOVES_LEFT_V1 = 2;
+  }
+  optional MovesLeftFormat moves_left = 6;
 }
 
 message Format {

--- a/proto/net.proto
+++ b/proto/net.proto
@@ -149,9 +149,8 @@ message NetworkFormat {
 
   // Moves left head architecture
   enum MovesLeftFormat {
-    MOVES_LEFT_UNKNOWN = 0;
-    MOVES_LEFT_NONE = 1;
-    MOVES_LEFT_V1 = 2;
+    MOVES_LEFT_NONE = 0;
+    MOVES_LEFT_V1 = 1;
   }
   optional MovesLeftFormat moves_left = 6;
 }


### PR DESCRIPTION
Protobuf changes for moves left head.

Since moves left head is optional, the networks with it are backwards compatible with the older lc0 versions without support for it. The moves left head is just not computed when it's not supported.