### PR TITLE
Add enum for parameterized value head.

### DIFF
--- a/proto/net.proto
+++ b/proto/net.proto
@@ -147,6 +147,7 @@ message NetworkFormat {
     VALUE_UNKNOWN = 0;
     VALUE_CLASSICAL = 1;
     VALUE_WDL = 2;
+    VALUE_PARAM = 3;
   }
   optional ValueFormat value = 5;
 


### PR DESCRIPTION
This will result in the value head having more than 3 outputs (exact number to be decided after more experimentation with possible formulas, possibly 7) which form inputs to be combined with the 50 move rule value (in hectoplies) in order to calculate a WDL distribution for any 50 move rule offset.

It would also be presumed that any network will zero out the 50 move rule plane of the actual net input if using this value head output type regardless of the actual input type enum value.