### PR TITLE
add float16 encoding

### DIFF
--- a/proto/net.proto
+++ b/proto/net.proto
@@ -92,6 +92,13 @@ message Weights {
     optional Layer ln2_betas = 6;
   }
 
+  enum Encoding {
+    UNKNOWN = 0;
+    LINEAR16 = 1;
+    FLOAT16 = 2;
+  }
+  optional Encoding encoding = 37;
+
   // Input convnet.
   optional ConvBlock input = 1;
 
@@ -211,7 +218,7 @@ message Format {
     UNKNOWN = 0;
     LINEAR16 = 1;
   }
-
+  // Here for comatibility with old nets, the correct one is in Weights.
   optional Encoding weights_encoding = 1;
   // If network_format is missing, it's assumed to have
   // INPUT_CLASSICAL_112_PLANE / OUTPUT_CLASSICAL / NETWORK_CLASSICAL format.


### PR DESCRIPTION
~The encoding is moved to the Weights where it makes sense and can be used where the weights are passed around without needing to keep track of the encoding separately.~
Turns out it is more convenient to have the encoding in each `Layer`. 
Also adds a `dims` field per `Layer` to store the tensor dimensions.